### PR TITLE
[leptrino.launch] accept device port id as an argument.

### DIFF
--- a/launch/leptrino.launch
+++ b/launch/leptrino.launch
@@ -1,6 +1,7 @@
 <launch>
+  <arg name="comport" default="/dev/ttyUSB0" />
   <node pkg="leptrino_force_torque" type="leptrino_force_torque" name="leptrino_force_torque" output="screen">
-  	<param name="com_port" value="/dev/ttyUSB0" />  	  	
+  	<param name="com_port" value="$(arg comport)" />  	  	
   </node>
 </launch>  
  


### PR DESCRIPTION
With this we can now specify device port id as an option at runtime.

```
$ roslaunch leptrino_force_torque leptrino.launch    (default)

$ roslaunch leptrino_force_torque leptrino.launch devport:=/dev/ttyUSB1
```
